### PR TITLE
Initialize logger with validated configuration

### DIFF
--- a/PlexCost/Program.cs
+++ b/PlexCost/Program.cs
@@ -25,12 +25,21 @@ namespace PlexCost
             {
 
                 var config = PlexCostConfig.FromEnvironment();
+                LoggerService.Initialize(config);
                 PlexCostConfig.Validate(config);
 
-                // Initialize Discord bot
-                var discord = new DiscordService(config.DiscordBotToken, config.SavingsJsonPath, config.DataJsonPath, config.DiscordLogChannelId);
-                await discord.InitializeAsync();
-                LogInformation("Discord slash‐command service initialized.");
+                // Initialize Discord bot if configured
+                DiscordService? discord = null;
+                if (!string.IsNullOrWhiteSpace(config.DiscordBotToken))
+                {
+                    discord = new DiscordService(config.DiscordBotToken, config.SavingsJsonPath, config.DataJsonPath, config.DiscordLogChannelId);
+                    await discord.InitializeAsync();
+                    LogInformation("Discord slash‐command service initialized.");
+                }
+                else
+                {
+                    LogInformation("Discord credentials not provided; skipping slash-command service initialization.");
+                }
 
                 // Initialize record tracking
                 var recordService = new RecordService(config.DataJsonPath);


### PR DESCRIPTION
## Summary
- initialize logging with a console fallback and configure sinks from the validated environment config
- keep Azure Monitor and Discord sinks optional while logging initialization issues to the console
- hook logger initialization early in Program so validation errors are emitted before shutdown

## Testing
- dotnet build PlexCost/PlexCost.csproj


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693957cd65c4832f8c8521ef6b04ef5a)